### PR TITLE
Add after_scripts node

### DIFF
--- a/swaggertosdk/generate_python_sdk.py
+++ b/swaggertosdk/generate_python_sdk.py
@@ -52,6 +52,7 @@ def generate(config_path, sdk_folder, project_pattern, restapi_git_folder, autor
                           local_conf,
                           autorest_bin)
             update(absolute_generated_path, sdk_folder, global_conf, local_conf)
+            execute_after_script(sdk_folder, global_conf, local_conf)
 
 
 def generate_main():


### PR DESCRIPTION
@veronicagg adds an after_scripts node:
```json
    "storage.2017-06-01": {
      "after_scripts": [
        "pwd",
        "python ./scripts/multiapi_init_gen.py azure-mgmt-storage"
      ],
      "autorest_options": {
        "namespace": "azure.mgmt.storage.v2017_06_01",
        "tag": "package-2017-06"
      },
      "build_dir": "azure-mgmt-storage/azure/mgmt/storage/v2017_06_01",
      "generated_relative_base_directory": "azure/mgmt/storage/v2017_06_01",
      "markdown": "specification/storage/resource-manager/readme.md",
      "output_dir": "azure-mgmt-storage/azure/mgmt/storage/v2017_06_01"
    },
```

Thoughts?